### PR TITLE
Function "Get-WuReport" - fix passing an empty string to the function "Get-RebootDelay"

### DIFF
--- a/WuReport-Client/Functions/Private/Get-RebootDelay.ps1
+++ b/WuReport-Client/Functions/Private/Get-RebootDelay.ps1
@@ -29,6 +29,7 @@ function Get-RebootDelay {
     Write-Verbose -Message  "$myName Starting the function..."
 
     try {
+        Write-Verbose -Message "$myName Parsing string with datestamp: $StartDateString"
         [datetime]$dateStart    = [datetime]::Parse($StartDateString)
     }
     catch {

--- a/WuReport-Client/Functions/Public/Get-WuReport.ps1
+++ b/WuReport-Client/Functions/Public/Get-WuReport.ps1
@@ -86,10 +86,12 @@ function Get-WuReport {
     [string]$timeStampUpdatesLast   = $reportLast.TimeStampUpdatesFound
 
     switch ($true) {
-        ($null -ne $timeStampRebootLast)    {
+        ($timeStampRebootLast.Length -gt 0)     {
+            Write-Verbose -Message "$myName Last timestamp when pending reboot was detected: $timeStampRebootLast"
             [bool]$delayExceededReboot  = Get-RebootDelay -StartDateString $timeStampRebootLast -DelayMax $DelayMax -Weekends $Weekends
         }
-        ($null -ne $timeStampUpdatesLast)   {
+        ($timeStampUpdatesLast.Length -gt 0)    {
+            Write-Verbose -Message "$myName Last timestamp when pending updates were detected: $timeStampUpdatesLast"
             [bool]$delayExceededUpdates = Get-RebootDelay -StartDateString $timeStampUpdatesLast -DelayMax $DelayMax -Weekends $Weekends
         }
         Default {


### PR DESCRIPTION
Function "Get-WuReport" - fix passing an empty string to the function "Get-RebootDelay"